### PR TITLE
ga/apiUrl override option

### DIFF
--- a/src/__tests__/convertMarkdownToPdf.test.ts
+++ b/src/__tests__/convertMarkdownToPdf.test.ts
@@ -103,11 +103,37 @@ describe("convertMarkdownToPdf", () => {
 
       expect(mockedCreateConversionPayload).toHaveBeenCalledWith(mockMarkdown, "Custom Title", "January 1, 2025");
       expect(mockedAxiosPost).toHaveBeenCalledWith(`${M2PDF_API_URL}/v1/markdown`, mockPayload);
-      expect(mockedPollConversionStatus).toHaveBeenCalledWith(mockPath);
+      expect(mockedPollConversionStatus).toHaveBeenCalledWith(mockPath, M2PDF_API_URL);
       expect(mockedDownloadPdf).toHaveBeenCalledWith(mockDownloadUrl, {
         downloadPath: undefined,
         returnBytes: true,
       });
+      expect(result).toBe(mockPdfBuffer);
+    });
+
+    it("should use custom apiUrl when provided", async () => {
+      const customApiUrl = "https://custom.api.example.com";
+      mockedAxiosPost.mockResolvedValueOnce(mockSuccessResponse);
+
+      const result = await convertMarkdownToPdf(mockMarkdown, {
+        onPaymentRequest: mockPaymentHandler,
+        apiUrl: customApiUrl,
+      });
+
+      expect(mockedAxiosPost).toHaveBeenCalledWith(`${customApiUrl}/v1/markdown`, mockPayload);
+      expect(mockedPollConversionStatus).toHaveBeenCalledWith(mockPath, customApiUrl);
+      expect(result).toBe(mockPdfBuffer);
+    });
+
+    it("should use default apiUrl when not provided", async () => {
+      mockedAxiosPost.mockResolvedValueOnce(mockSuccessResponse);
+
+      const result = await convertMarkdownToPdf(mockMarkdown, {
+        onPaymentRequest: mockPaymentHandler,
+      });
+
+      expect(mockedAxiosPost).toHaveBeenCalledWith(`${M2PDF_API_URL}/v1/markdown`, mockPayload);
+      expect(mockedPollConversionStatus).toHaveBeenCalledWith(mockPath, M2PDF_API_URL);
       expect(result).toBe(mockPdfBuffer);
     });
 

--- a/src/convertMarkdownToPdf.ts
+++ b/src/convertMarkdownToPdf.ts
@@ -19,6 +19,7 @@ export async function convertMarkdownToPdf(
     title = "Markdown2PDF.ai converted document",
     downloadPath,
     returnBytes = false,
+    apiUrl = M2PDF_API_URL,
   } = options;
 
   if (!onPaymentRequest) throw new Markdown2PdfError("Payment required but no handler provided.");
@@ -40,7 +41,7 @@ export async function convertMarkdownToPdf(
       if (Date.now() - startTime > M2PDF_TIMEOUTS.POLLING)
         throw new Markdown2PdfError(`Conversion timed out after ${M2PDF_TIMEOUTS.POLLING}ms`);
 
-      const response = await withTimeout(axios.post(`${M2PDF_API_URL}/v1/markdown`, payload), M2PDF_TIMEOUTS.REQUEST);
+      const response = await withTimeout(axios.post(`${apiUrl}/v1/markdown`, payload), M2PDF_TIMEOUTS.REQUEST);
 
       if (response.status === 402) {
         const l402Offer = response.data;
@@ -90,7 +91,7 @@ export async function convertMarkdownToPdf(
   }
 
   // Poll for conversion status and get final URL
-  const finalDownloadUrl = await pollConversionStatus(path);
+  const finalDownloadUrl = await pollConversionStatus(path, apiUrl);
 
   // Download and return the PDF
   return downloadPdf(finalDownloadUrl, { downloadPath, returnBytes });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,7 +4,7 @@ import { createWriteStream } from "fs";
 import { pipeline } from "stream/promises";
 import { Markdown2PdfError } from "./errors.js";
 import { OfferDetails } from "./types.js";
-import { M2PDF_API_URL, M2PDF_POLL_INTERVAL, M2PDF_TIMEOUTS } from "./constants.js";
+import { M2PDF_POLL_INTERVAL, M2PDF_TIMEOUTS } from "./constants.js";
 import { sleep, buildUrl, withTimeout } from "./utils.js";
 
 export const handlePayment = async (
@@ -37,8 +37,8 @@ export const handlePayment = async (
   await sleep(M2PDF_POLL_INTERVAL);
 };
 
-export const pollConversionStatus = async (path: string): Promise<string> => {
-  const statusUrl = buildUrl(path, M2PDF_API_URL);
+export const pollConversionStatus = async (path: string, apiUrl: string): Promise<string> => {
+  const statusUrl = buildUrl(path, apiUrl);
   const pollStartTime = Date.now();
 
   while (true) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type ConvertToPdfParams = {
   title?: string;
   downloadPath?: string;
   returnBytes?: boolean;
+  apiUrl?: string;
 };
 
 export class Markdown2PdfError extends Error {


### PR DESCRIPTION
# What's changed
- added extra `apiUrl` override option to `ConvertToPdfParams` and equivalent tests to support it